### PR TITLE
Add retry when IPF convergence fails applying epsilon to seed

### DIFF
--- a/microsimulation/static.py
+++ b/microsimulation/static.py
@@ -127,6 +127,9 @@ class SequentialMicrosynthesis(common.Base):
     # now the full seeded microsynthesis
     if self.fast_mode:
       msynth = hl.ipf(self.seed, [np.array([0, 3]), np.array([1, 2])], [oa_eth["result"].astype(float), age_sex.astype(float)])
+      if not msynth["conv"]:
+        print(f"Failed to converge with {year - 1} seed, retry applying epsilon...")
+        msynth = hl.ipf(self.seed + np.finfo(np.float64).tiny, [np.array([0, 3]), np.array([1, 2])], [oa_eth["result"].astype(float), age_sex.astype(float)])  
     else:
       msynth = hl.qisi(self.seed, [np.array([0, 3]), np.array([1, 2])], [oa_eth["result"], age_sex])
     if not msynth["conv"]:


### PR DESCRIPTION
For several LADs, humanleague IPF fitting can fail to converge:
- City of London (E09000001)
- Isle of Scilly (E06000053)
- Oadby and Wigston (E07000135)

The lack of convergence appears to be due to no update applied under some seed initialisations when elements are exactly zero (see [IPF.h](https://github.com/virgesmith/humanleague/blob/5951879db64450300d43527de3d0b5e5809d82b7/src/IPF.h#L73-L74) with the`rScale()` call in [Microsynthesis.h](https://github.com/virgesmith/humanleague/blob/5951879db64450300d43527de3d0b5e5809d82b7/src/Microsynthesis.h#L187-L198)).

To fix this, when convergence fails, the fitting is retried with a tiny value (epsilon) [added to the seed](https://github.com/alan-turing-institute/microsimulation/commit/5897287756aadef002f34eca8349a3882870bfa4).